### PR TITLE
add scrapper for 울산광역시. fix 광진구

### DIFF
--- a/scrap/local_councils/__init__.py
+++ b/scrap/local_councils/__init__.py
@@ -3,3 +3,4 @@
 광역자치단체 별로 폴더를 만들어서 관리합니다.
 """
 from .daejeon import *
+from .ulsan import *

--- a/scrap/local_councils/daejeon.py
+++ b/scrap/local_councils/daejeon.py
@@ -28,9 +28,7 @@ def scrap_65(url = 'https://council.donggu.go.kr/kr/member/active') -> ScrapResu
         if profile_link:
             data_uid = profile_link.get('data-uid')
             if data_uid:
-                profile_url = base_url + f'/kr/member/profile_popup?uid={data_uid}'  # 예시 URL
-                print(profile_url)
-
+                profile_url = base_url + f'/kr/member/profile_popup?uid={data_uid}'
                 profile_soup = get_soup(profile_url, verify=False)
                 party_info = profile_soup.find('strong', string='정      당')
                 if party_info and (party_span := party_info.find_next('span')) is not None:

--- a/scrap/local_councils/seoul/gwangjingu.py
+++ b/scrap/local_councils/seoul/gwangjingu.py
@@ -13,8 +13,8 @@ def scrap_gwangjingu(url = "https://council.gwangjin.go.kr/kr/member/active") ->
     councilors: List[Councilor] = []
 
     for profile in soup.find_all('div', class_='profile'):
-        name_tag = profile.find("div", class_="name")
-        name = name_tag.find_next('strong').string(strip=True) if name_tag else "이름 정보 없음"
+        name_tag = profile.find("div", class_="name").find_next('strong')
+        name = name_tag.get_text(strip=True) if name_tag else "이름 정보 없음"
         party = '정당 정보 없음'
 
         party_info = profile.find('em', string = '소속정당')

--- a/scrap/local_councils/ulsan.py
+++ b/scrap/local_councils/ulsan.py
@@ -1,0 +1,148 @@
+from urllib.parse import urlparse
+
+from typing import List
+from scrap.utils.types import CouncilType, Councilor, ScrapResult
+from scrap.utils.requests import get_soup
+import re
+
+regex_pattern = re.compile(r'정\s*\S*\s*당', re.IGNORECASE)  # Case-insensitive
+
+def scrap_70(url = 'https://council.junggu.ulsan.kr/content/member/memberName.html') -> ScrapResult:
+    '''울산시 중구 페이지에서 의원 상세약력 스크랩
+
+    :param url: 의원 목록 사이트 url
+    :return: 의원들의 이름과 정당 데이터를 담은 ScrapResult 객체
+    '''
+    soup = get_soup(url, verify=False)
+    councilors: List[Councilor] = []
+
+    for profile in soup.find_all('dl'):
+        name_tag = profile.find("dd", class_="name")
+        name = name_tag.get_text(strip=True) if name_tag else "이름 정보 없음"
+        
+        party = "정당 정보 없음"
+        party_info = list(filter(lambda x: regex_pattern.search(str(x)), profile.find_all("dd")))
+        if party_info and (party_span := party_info[0].find_next('span').find_next('span')) is not None:
+            party = party_span.text
+
+        councilors.append(Councilor(name=name, party=party))
+
+    return ScrapResult(
+        council_id="ulsan-junggu",
+        council_type=CouncilType.LOCAL_COUNCIL,
+        councilors=councilors
+    )
+
+def scrap_71(url = 'https://www.namgucouncil.ulsan.kr/content/member/memberName.html') -> ScrapResult:
+    '''울산시 남구 페이지에서 의원 상세약력 스크랩
+
+    :param url: 의원 목록 사이트 url
+    :return: 의원들의 이름과 정당 데이터를 담은 ScrapResult 객체
+    '''
+    soup = get_soup(url, verify=False)
+    councilors: List[Councilor] = []
+
+    for profile in soup.find_all('dl'):
+        name_tag = profile.find("dd", class_="name")
+        name = name_tag.get_text(strip=True).replace(" 의원", "") if name_tag else "이름 정보 없음"
+
+        party = "정당 정보 없음"
+        party_info = list(filter(lambda x: regex_pattern.search(str(x)), profile.find_all("dd")))
+        if party_info and (party_span := party_info[0].find_next('span').find_next('span')) is not None:
+            party = party_span.text
+
+        councilors.append(Councilor(name=name, party=party))
+
+    return ScrapResult(
+        council_id="ulsan-namgu",
+        council_type=CouncilType.LOCAL_COUNCIL,
+        councilors=councilors
+    )
+
+def scrap_72(url = 'https://www.donggu-council.ulsan.kr/source/korean/member/active.html') -> ScrapResult:
+    '''울산시 동구 페이지에서 의원 상세약력 스크랩
+
+    :param url: 의원 목록 사이트 url
+    :return: 의원들의 이름과 정당 데이터를 담은 ScrapResult 객체
+    '''
+    soup = get_soup(url, verify=False, encoding='euc-kr')
+    councilors: List[Councilor] = []
+
+    for profile in soup.find_all('div', class_='profile'):
+        name_tag = profile.find("li", class_="name")
+        # () 안에 있는 한자를 제거 (ex. 김영희(金英姬) -> 김영희)
+        name = name_tag.get_text(strip=True).split('(')[0] if name_tag else "이름 정보 없음"
+        party = "정당 정보 없음"
+        party_info = list(filter(lambda x: regex_pattern.search(str(x)), profile.find_all("li")))
+        if party_info:
+            party = party_info[0].get_text(strip=True).split(': ')[1]
+        councilors.append(Councilor(name=name, party=party))
+
+    return ScrapResult(
+        council_id="ulsan-donggu",
+        council_type=CouncilType.LOCAL_COUNCIL,
+        councilors=councilors
+    )
+
+def scrap_73(url = 'https://council.bukgu.ulsan.kr/kr/member/active.do') -> ScrapResult:
+    '''울산시 북구 페이지에서 의원 상세약력 스크랩
+
+    :param url: 의원 목록 사이트 url
+    :return: 의원들의 이름과 정당 데이터를 담은 ScrapResult 객체
+    '''
+    soup = get_soup(url, verify=False)
+    councilors: List[Councilor] = []
+
+    for profile in soup.find_all('dl', class_='profile'):
+        name_tag = profile.find("strong", class_="name")
+        # () 안에 있는 한자를 제거 (ex. 김영희(金英姬) -> 김영희)
+        name = name_tag.get_text(strip=True).split('(')[0] if name_tag else "이름 정보 없음"
+        party = "정당 정보 없음"
+        party_info = list(filter(lambda x: regex_pattern.search(str(x)), profile.find_all("li")))
+        if party_info:
+            party = party_info[0].get_text(strip=True).split(': ')[1]
+        councilors.append(Councilor(name=name, party=party))
+
+    return ScrapResult(
+        council_id="ulsan-bukgu",
+        council_type=CouncilType.LOCAL_COUNCIL,
+        councilors=councilors
+    )
+
+def scrap_74(url = 'https://assembly.ulju.ulsan.kr/kr/member/active') -> ScrapResult:
+    '''울산시 울주군 페이지에서 의원 상세약력 스크랩
+
+    :param url: 의원 목록 사이트 url
+    :return: 의원들의 이름과 정당 데이터를 담은 ScrapResult 객체
+    '''
+    soup = get_soup(url, verify=False)
+    councilors: List[Councilor] = []
+
+    # 프로필 링크 스크랩을 위해 base_url 추출
+    parsed_url = urlparse(url)
+    base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+    for profile in soup.find_all('div', class_='profile'):
+        name_tag = profile.find("em", class_="name")
+        name = name_tag.get_text(strip=True) if name_tag else "이름 정보 없음"
+        party = '정당 정보 없음'
+
+        # 프로필보기 링크 가져오기
+        profile_link = profile.find('a', class_='start')
+        if profile_link:
+            profile_url = base_url + profile_link['href']
+            profile_soup = get_soup(profile_url, verify=False)
+            party_info = profile_soup.find('em', string=regex_pattern)
+            if party_info and (party_span := party_info.find_next('span')) is not None:
+                party = party_span.text
+
+        councilors.append(Councilor(name=name, party=party))
+
+    return ScrapResult(
+        council_id="ulsan_uljugun",
+        council_type=CouncilType.LOCAL_COUNCIL,
+        councilors=councilors
+    )
+
+if __name__ == '__main__':
+    print(scrap_70())

--- a/scrap/utils/spreadsheet.py
+++ b/scrap/utils/spreadsheet.py
@@ -49,13 +49,13 @@ def main() -> None:
     print(scrap_junggu(data[1]['상세약력 링크']))
     print(scrap_gwangjingu(data[4]['상세약력 링크']))
     print(scrap_dongdaemungu(data[5]['상세약력 링크']))
-    for n in range (65, 70):
+    for n in range (65, 75):
         function_name = f"scrap_{n}"
         if hasattr(sys.modules[__name__], function_name):
             function_to_call = getattr(sys.modules[__name__], function_name)
             print(function_to_call)
-            if n in [66]:
-                result = function_to_call() # 스프레드시트 링크 터짐
+            if n in [66, 70, 74]:
+                result = function_to_call() # 스프레드시트 링크 터짐 (울산 울주군처럼 애먼데 링크인 경우도 있다)
             else:
                 result = function_to_call(data[n - 1]['상세약력 링크'])
             print(result)


### PR DESCRIPTION
regex_pattern (정당, 정</span>당 등을 모두 찾기 위해서..) 을 문서 맨 위에 고정.

70은 67과 비슷
71은 70과 같음
72는 인코딩이 euc-kr 

제안
- 아래 코드에서 council_id는 숫자로 대체하기. (이름 매번 지정보다는..)
```
return ScrapResult(
        council_id="ulsan-namgu",
        council_type=CouncilType.LOCAL_COUNCIL,
        councilors=councilors
    )
```
- 정당 찾는 regex_pattern은 라이브러리에 넣어두기
- 같은 함수는 묶을 수 있도록 하기
- 같은 형태인데 'div'가 'dl'로 바뀐다든지만 하는 경우는 핸들할 수 있는 스켈레톤 만들기 
- `.find_next('span')` 이 2번 들어가는 _71이나 '소속정당: '인 _72 예제를 보니, 정당이름을 set으로 정리해놓고, 
```
text = "소속정1당2: 무소속"
pattern = r"무소속"
matches = re.findall(pattern, text)
if matches:
```
이렇게 두는게 좋지 않을까? 하는 생각이 든다. 