### PR TITLE
[scrap] 국회의원 스크랩 링크 변경

### DIFF
--- a/scrap/national_council.py
+++ b/scrap/national_council.py
@@ -6,13 +6,14 @@ import xml.etree.ElementTree as ET
 
 BASE_DIR = os.path.join(os.path.dirname(__file__), os.pardir)
 
+
 def scrap_national_council(cd: int) -> ScrapResult:
 	'''열린국회정보 Open API를 이용해 역대 국회의원 인적사항 스크랩
 	_data 폴더에 assembly_api_key.json 파일을 만들어야 하며,
 	해당 JSON은 {"key":"(Open API에서 발급받은 인증키)"} 꼴을 가져야 한다.
 	https://open.assembly.go.kr/portal/data/service/selectAPIServicePage.do/OBL7NF0011935G18076#none
 
-	:param cd: 국회의원 대수. 제20대 국회의원을 스크랩하고자 하면 20
+	:param cd: 국회의원 대수. 제21대 국회의원을 스크랩하고자 하면 21
 	:return: 국회의원들의 이름과 정당 데이터를 담은 ScrapResult 객체
 	'''
 
@@ -22,7 +23,7 @@ def scrap_national_council(cd: int) -> ScrapResult:
 	with open(key_json_path, 'r') as key_json:
 		assembly_key = json.load(key_json)['key']
 	
-	request_url = f"https://open.assembly.go.kr/portal/openapi/npffdutiapkzbfyvr?KEY={assembly_key}&UNIT_CD={cd + 100000}"
+	request_url = f"https://open.assembly.go.kr/portal/openapi/nwvrqwxyaytdsfvhu?KEY={assembly_key}&pSize=500&UNIT_CD={cd + 100000}"
 	response = requests.get(request_url)
 
 	if response.status_code != 200:
@@ -43,5 +44,6 @@ def scrap_national_council(cd: int) -> ScrapResult:
 		councilors=councilors
 	)
 
+
 if __name__ == '__main__':
-	print(scrap_national_council(20))
+	print(scrap_national_council(21))


### PR DESCRIPTION
Touches on #27 
열린국회정보 OpenAPI에서 사용하던 API를 역대 국회의원 인적사항에서 국회의원 인적사항으로 변경합니다.
총 298명의 국회의원 모두 정상적으로 스크랩됩니다.